### PR TITLE
Ensure Heroku builds install client devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/server.js",
   "scripts": {
     "start": "node server/server.js",
-    "heroku-postbuild": "cd client && npm install && npm run build"
+    "heroku-postbuild": "npm install --prefix client --include=dev && npm run build --prefix client"
   },
   "engines": {
     "node": ">=18.0.0",
@@ -28,7 +28,11 @@
     "socket.io": "^4.8.1",
     "speakeasy": "^2.0.0"
   },
-  "keywords": ["react", "express", "mongodb"],
+  "keywords": [
+    "react",
+    "express",
+    "mongodb"
+  ],
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- update the Heroku postbuild script to install the client dependencies with dev packages before building the React app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82682a8f48327993f13c549c636c3