### PR TITLE
Fix Express fallback route for React build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/server.js",
   "scripts": {
     "start": "node server/server.js",
-    "heroku-postbuild": "cd client && npm install && npm run build"
+    "heroku-postbuild": "npm install --prefix client --production=false && npm run --prefix client build"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/server/server.js
+++ b/server/server.js
@@ -2689,7 +2689,11 @@ if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '../client/build')));
   
   // Handle React Router - send all non-API requests to index.html
-  app.get('*', (req, res) => {
+  const nonApiRoutePattern = new RegExp(
+    `^(?!${escapeRegExp(API_PREFIX)}(?:$|/)).*`
+  );
+
+  app.get(nonApiRoutePattern, (req, res) => {
     // Skip API routes
     if (req.path.startsWith(API_PREFIX)) {
       return res.status(404).json({ error: "Not found" });


### PR DESCRIPTION
## Summary
- update the Heroku postbuild script to install the client with dev dependencies before running the React build
- replace the production catch-all route with an Express 5 compatible regex so non-API requests reach the React index.html without crashing

## Testing
- npm run --prefix client build

------
https://chatgpt.com/codex/tasks/task_e_68d82682a8f48327993f13c549c636c3